### PR TITLE
fix supervisor error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ COPY etc/litestream.yml /etc/litestream.yml
 # Copy startup script and supervisor config
 COPY scripts/run.sh /usr/local/memos/run.sh
 COPY scripts/supervisord.conf /etc/supervisord.conf
+COPY scripts/conf.d/memos_service.conf /etc/supervisord/conf.d/memos_service.conf
+COPY scripts/conf.d/memogram_service.conf /usr/local/memos/memogram_service.conf
 # We will create two small helper scripts for supervisor
 COPY scripts/start_memos_service.sh /usr/local/memos/start_memos_service.sh
 COPY scripts/start_memogram_service.sh /usr/local/memos/start_memogram_service.sh

--- a/scripts/conf.d/memogram_service.conf
+++ b/scripts/conf.d/memogram_service.conf
@@ -1,0 +1,16 @@
+[program:memogram_service]
+command=/usr/local/memos/start_memogram_service.sh
+autostart=true
+autorestart=true
+startsecs=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+environment=
+    BOT_TOKEN="%(ENV_BOT_TOKEN)s",
+    DB_PATH="%(ENV_DB_PATH)s",
+    MEMOS_PORT="%(ENV_MEMOS_PORT)s",
+    MEMOS_TOKEN="%(ENV_MEMOS_TOKEN)s",
+    TG_ID="%(ENV_TG_ID)s",
+    TZ="%(ENV_TZ)s"

--- a/scripts/conf.d/memos_service.conf
+++ b/scripts/conf.d/memos_service.conf
@@ -1,0 +1,20 @@
+[program:memos_service]
+command=/usr/local/memos/start_memos_service.sh
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopsignal=TERM
+stopwaitsecs=10
+environment=
+    DB_PATH="%(ENV_DB_PATH)s",
+    LITESTREAM_REPLICA_BUCKET="%(ENV_LITESTREAM_REPLICA_BUCKET)s",
+    LITESTREAM_REPLICA_PATH="%(ENV_LITESTREAM_REPLICA_PATH)s",
+    LITESTREAM_REPLICA_ENDPOINT="%(ENV_LITESTREAM_REPLICA_ENDPOINT)s",
+    LITESTREAM_ACCESS_KEY_ID="%(ENV_LITESTREAM_ACCESS_KEY_ID)s",
+    LITESTREAM_SECRET_ACCESS_KEY="%(ENV_LITESTREAM_SECRET_ACCESS_KEY)s",
+    MEMOS_MODE="%(ENV_MEMOS_MODE)s",
+    MEMOS_PORT="%(ENV_MEMOS_PORT)s",
+    TZ="%(ENV_TZ)s"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -11,6 +11,15 @@ use_litestream_check() {
     [ -n "$LITESTREAM_REPLICA_BUCKET" ] && [ -n "$LITESTREAM_REPLICA_PATH" ] && [ -n "$LITESTREAM_REPLICA_ENDPOINT" ] && [ -n "$LITESTREAM_ACCESS_KEY_ID" ] && [ -n "$LITESTREAM_SECRET_ACCESS_KEY" ]
 }
 
+use_memogram_check() {
+    [ -x /usr/local/memos/memogram ] && [ -n "$BOT_TOKEN" ]
+}
+
+if use_memogram_check; then
+    mkdir -p /etc/supervisord/conf.d
+    cp /usr/local/memos/memogram_service.conf /etc/supervisord/conf.d/memogram_service.conf
+fi
+
 cd /usr/local/memos # Ensure we are in the correct working directory
 
 # Check for MEMOS_TOKEN and TG_ID and save it to data.txt

--- a/scripts/supervisord.conf
+++ b/scripts/supervisord.conf
@@ -6,40 +6,5 @@ pidfile=/tmp/supervisord.pid
 loglevel=info
 user=root
 
-[program:memos_service]
-command=/usr/local/memos/start_memos_service.sh
-autostart=true
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-stopsignal=TERM
-stopwaitsecs=10
-environment=
-    DB_PATH="%(ENV_DB_PATH)s",
-    LITESTREAM_REPLICA_BUCKET="%(ENV_LITESTREAM_REPLICA_BUCKET)s",
-    LITESTREAM_REPLICA_PATH="%(ENV_LITESTREAM_REPLICA_PATH)s",
-    LITESTREAM_REPLICA_ENDPOINT="%(ENV_LITESTREAM_REPLICA_ENDPOINT)s",
-    LITESTREAM_ACCESS_KEY_ID="%(ENV_LITESTREAM_ACCESS_KEY_ID)s",
-    LITESTREAM_SECRET_ACCESS_KEY="%(ENV_LITESTREAM_SECRET_ACCESS_KEY)s",
-    MEMOS_MODE="%(ENV_MEMOS_MODE)s",
-    MEMOS_PORT="%(ENV_MEMOS_PORT)s",
-    TZ="%(ENV_TZ)s"
-
-[program:memogram_service]
-command=/usr/local/memos/start_memogram_service.sh
-autostart=true
-autorestart=true
-startsecs=10
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-environment=
-    BOT_TOKEN="%(ENV_BOT_TOKEN)s",
-    DB_PATH="%(ENV_DB_PATH)s",
-    MEMOS_PORT="%(ENV_MEMOS_PORT)s",
-    MEMOS_TOKEN="%(ENV_MEMOS_TOKEN)s",
-    TG_ID="%(ENV_TG_ID)s",
-    TZ="%(ENV_TZ)s"
+[include]
+files = /etc/supervisord/conf.d/*.conf


### PR DESCRIPTION
修复启动时的问题：
```
Error: Format string '\nBOT_TOKEN="%(ENV_BOT_TOKEN)s",\nDB_PATH="%(ENV_DB_PATH)s",\nMEMOS_PORT="%(ENV_MEMOS_PORT)s",\nMEMOS_TOKEN="%(ENV_MEMOS_TOKEN)s",\nTG_ID="%(ENV_TG_ID)s",\nTZ="%(ENV_TZ)s"' for 'environment' contains names ('ENV_BOT_TOKEN') which cannot be expanded. Available names: ENV_DB_PATH, ENV_HOME, ENV_HOSTNAME, ENV_LITESTREAM_ACCESS_KEY_ID, ENV_LITESTREAM_REPLICA_BUCKET, ENV_LITESTREAM_REPLICA_ENDPOINT, ENV_LITESTREAM_REPLICA_PATH, ENV_LITESTREAM_SECRET_ACCESS_KEY, ENV_MEMOGRAM_TAG, ENV_MEMOS_MODE, ENV_MEMOS_PORT, ENV_OLDPWD, ENV_PATH, ENV_PWD, ENV_SERVER_ADDR, ENV_SHLVL, ENV_TZ, group_name, here, host_node_name, numprocs, process_num, program_name in section 'program:memogram_service' (file: '/etc/supervisord.conf')
```